### PR TITLE
fix(network): only prefix a scheme when the URL has none

### DIFF
--- a/RuntimeBridges/Android/app/src/main/kotlin/eu/kanade/tachiyomi/network/Requests.kt
+++ b/RuntimeBridges/Android/app/src/main/kotlin/eu/kanade/tachiyomi/network/Requests.kt
@@ -13,9 +13,22 @@ private val DEFAULT_CACHE_CONTROL = CacheControl.Builder().maxAge(10, MINUTES).b
 private val DEFAULT_HEADERS = Headers.Builder().build()
 private val DEFAULT_BODY: RequestBody = FormBody.Builder().build()
 
+/** Matches a URI scheme prefix, for example `http:`, `https:` or `intent:`. */
+private val SCHEME_PREFIX = Regex("^[a-zA-Z][a-zA-Z0-9+.\\-]*:")
+
+/**
+ * Prefix a scheme onto a bare host or a protocol-relative URL.
+ *
+ * Only strings with NO scheme at all are prefixed. A string that already carries one is passed
+ * through untouched so OkHttp can apply the WHATWG normalisation a browser would — sources
+ * routinely scrape URLs that are scheme-ful but not spelled `http://` or `https://` exactly:
+ * JSON-escaped (`https:\/\/host\/path`), upper-cased (`HTTPS://host`), or single-slashed
+ * (`https:/host`). Prefixing those produced `https://https:\/\/host…`, whose authority parses as
+ * `https`, so the request died with `UnknownHostException: https` instead of loading.
+ */
 fun String.normalizeUrl(): String {
     if (isBlank()) return this
-    if (startsWith("http://") || startsWith("https://")) return this
+    if (SCHEME_PREFIX.containsMatchIn(this)) return this
     if (startsWith("//")) return "https:$this"
     return "https://$this"
 }

--- a/RuntimeBridges/Desktop/src/main/kotlin/eu/kanade/tachiyomi/network/Requests.kt
+++ b/RuntimeBridges/Desktop/src/main/kotlin/eu/kanade/tachiyomi/network/Requests.kt
@@ -13,9 +13,22 @@ private val DEFAULT_CACHE_CONTROL = CacheControl.Builder().maxAge(10, MINUTES).b
 private val DEFAULT_HEADERS = Headers.Builder().build()
 private val DEFAULT_BODY: RequestBody = FormBody.Builder().build()
 
+/** Matches a URI scheme prefix, for example `http:`, `https:` or `intent:`. */
+private val SCHEME_PREFIX = Regex("^[a-zA-Z][a-zA-Z0-9+.\\-]*:")
+
+/**
+ * Prefix a scheme onto a bare host or a protocol-relative URL.
+ *
+ * Only strings with NO scheme at all are prefixed. A string that already carries one is passed
+ * through untouched so OkHttp can apply the WHATWG normalisation a browser would — sources
+ * routinely scrape URLs that are scheme-ful but not spelled `http://` or `https://` exactly:
+ * JSON-escaped (`https:\/\/host\/path`), upper-cased (`HTTPS://host`), or single-slashed
+ * (`https:/host`). Prefixing those produced `https://https:\/\/host…`, whose authority parses as
+ * `https`, so the request died with `UnknownHostException: https` instead of loading.
+ */
 fun String.normalizeUrl(): String {
     if (isBlank()) return this
-    if (startsWith("http://") || startsWith("https://")) return this
+    if (SCHEME_PREFIX.containsMatchIn(this)) return this
     if (startsWith("//")) return "https:$this"
     return "https://$this"
 }


### PR DESCRIPTION
## Problem

`String.normalizeUrl()` in `eu/kanade/tachiyomi/network/Requests.kt` (identical in the Desktop and Android bridges) prefixes `https://` onto every string that does not start with a literal `http://`, `https://` or `//`:

```kotlin
if (startsWith("http://") || startsWith("https://")) return this
if (startsWith("//")) return "https:$this"
return "https://$this"
```

Extensions routinely scrape URLs that carry a scheme in some other spelling:

- JSON-escaped — `https:\/\/host\/path`, which happens whenever a page returns its markup inside a JSON payload and the extension parses that with Jsoup
- upper-cased — `HTTPS://host` (`startsWith` is case-sensitive)
- single-slashed — `https:/host`

None of those match the two literal prefixes, so they get a scheme glued in front: `https://https:\/\/host…`. OkHttp parses the authority of that as `https`, and the request dies with:

```
java.net.UnknownHostException: https
	at okhttp3.Dns$Companion$DnsSystem.lookup(Dns.kt:50)
	...
	at eu.kanade.tachiyomi.network.interceptor.UncaughtExceptionInterceptor.intercept
```

Aniyomi itself never rewrites the string — `GET(url: String)` goes straight to `url.toHttpUrl()`, and OkHttp applies the same WHATWG normalisation a browser does (backslashes count as slashes, extra slashes collapse). That is why an extension that works in Aniyomi can fail here with a DNS error naming a host that appears nowhere in its code.

## Fix

Detect a scheme with a regex instead of matching two literal prefixes, and pass any scheme-ful string through untouched. Strings with no scheme at all keep the existing behaviour.

```kotlin
private val SCHEME_PREFIX = Regex("^[a-zA-Z][a-zA-Z0-9+.\-]*:")

fun String.normalizeUrl(): String {
    if (isBlank()) return this
    if (SCHEME_PREFIX.containsMatchIn(this)) return this
    if (startsWith("//")) return "https:$this"
    return "https://$this"
}
```

Applied to both `RuntimeBridges/Desktop` and `RuntimeBridges/Android`.

## Verification

Built the desktop bridge before and after and ran the same six installed extensions through it over the stdio protocol (`loadExtensions` → `search` → `getDetail` → `getVideoList`).

Five behave identically before and after — same result counts, including one that was already failing for an unrelated reason (its hardcoded CDN domain no longer resolves). The sixth is the one that hit this bug: it scrapes its player URL out of a JSON response, so the URL reaches `normalizeUrl` as `https:\/\/host\/path…`. Before the change its video list came back empty with `UnknownHostException: https`; after it returns both of its mirrors.
